### PR TITLE
Corrected Semantic Defintion of take(k)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ Examine| get(k)  |N.A       |N.A
     block till the key becomes available. When the key becomes available, all the blocked threads
     should be notified. Actual removal of the mapping can & should happen from only one of the
     threads. Therefore, the operation should be successful from only one thread. Hence, value
-    should be returned on only one of the threads and not on all the threads. Null should be
-    returned on threads on which the operation was not successful.
+    should be returned on only one of the threads and not on all the threads.
 - When a consumer is blocked on take(k) waiting for a key that is not available yet, it can be
     interrupted. Consumer should return in this case with an Interrupted exception.
 - Offer(k,v, time, unit) should behave similar to Offer(k,v) but time out when the specified amount


### PR DESCRIPTION
I'm not sure whether I'm right here. But I assume, the deleted sentence is wrong here. 
If several consumers (threads) are waiting blocked by a take(k) for being satisfied and one of them wins when k is put in, then the other consumers should remain waiting, isn't it? Instead of returning null as the removed sentence is intending.
But as I said, I'm not sure what your initial intention was. In different context both may be meaningful.

May be it is worth to implement a method covering you initial semantic (break blocking if another consumers wins) something like *takeAsWinner* or so.
  